### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 ansi_term = "0.12"
 clap = { version = "4.0", features = ["derive"] }
 csv = "1.3.0"
-cursive = { git = "https://github.com/gyscos/cursive", default-features = false, features = ["crossterm-backend"] }
+cursive = { version = "0.21.1", default-features = false, features = ["crossterm-backend"] }
 include_dir = { version = "0.7.3", features = ["glob"] }
 lazy_static = "1.4.0"
 nix = "0.26.2"


### PR DESCRIPTION
Since cursive has made a new release, use that instead of the git repo (which was failing when doing make install with a cargo vendor'd build due to the git not shipping a lockfile).